### PR TITLE
ResponseCacheMiddleware doesn't try to add entry without MaxAge

### DIFF
--- a/src/Weikio.ApiFramework.ResponceCache/ConfigureEndpointResponseCacheOptions.cs
+++ b/src/Weikio.ApiFramework.ResponceCache/ConfigureEndpointResponseCacheOptions.cs
@@ -74,7 +74,7 @@ namespace Weikio.ApiFramework.ResponceCache
                         ResponseCacheConfiguration = new ResponseCacheConfiguration(defaultAge, vary)
                     };
 
-                    var configurations = GetResponseCacheConfigurations(endpointCacheSection.GetSection("routes"));
+                    var configurations = GetResponseCacheConfigurations(endpointCacheSection.GetSection("Routes"));
 
                     foreach (var responseCacheConfiguration in configurations)
                     {

--- a/src/Weikio.ApiFramework.ResponceCache/ResponseCacheControlMiddleware.cs
+++ b/src/Weikio.ApiFramework.ResponceCache/ResponseCacheControlMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -92,7 +92,7 @@ namespace Weikio.ApiFramework.ResponceCache
                     {
                         var path = new PathString("/" + string.Join('/', requestPathPartsQueue));
 
-                        if (endpointCacheConfig.PathConfigurations.TryGetValue(path, out var cacheConfig))
+                        if (endpointCacheConfig.PathConfigurations.TryGetValue(path, out var cacheConfig) && cacheConfig.MaxAge > default(TimeSpan))
                         {
                             return new ResponseCacheCachedEntry(ResponseCacheConfigurationLevel.Route,
                                 new CacheControlHeaderValue() { Public = true, MaxAge = cacheConfig.MaxAge }, cacheConfig.Vary);
@@ -101,7 +101,7 @@ namespace Weikio.ApiFramework.ResponceCache
                         requestPathPartsQueue.Dequeue();
                     }
 
-                    if (endpointCacheConfig.ResponseCacheConfiguration?.MaxAge != default)
+                    if (endpointCacheConfig.ResponseCacheConfiguration != null && endpointCacheConfig.ResponseCacheConfiguration.MaxAge > default(TimeSpan))
                     {
                         return new ResponseCacheCachedEntry(ResponseCacheConfigurationLevel.Endpoint,
                             new CacheControlHeaderValue() { Public = true, MaxAge = endpointCacheConfig.ResponseCacheConfiguration.MaxAge },
@@ -109,7 +109,7 @@ namespace Weikio.ApiFramework.ResponceCache
                     }
                 }
 
-                if (_options.ResponseCacheConfiguration != null && _options.ResponseCacheConfiguration.MaxAge != default)
+                if (_options.ResponseCacheConfiguration != null && _options.ResponseCacheConfiguration.MaxAge > default(TimeSpan))
                 {
                     return new ResponseCacheCachedEntry(ResponseCacheConfigurationLevel.Global,
                         new CacheControlHeaderValue() { Public = true, MaxAge = _options.ResponseCacheConfiguration.MaxAge },


### PR DESCRIPTION
If the cache configuration is defined for routes only, the default endpoint cache configration causes the following error because MaxAge is `"00:00:00"`.

```
2021-07-23 07:16:42.6804|2|ERROR|Microsoft.AspNetCore.Server.IIS.Core.IISHttpServer|Connection ID "18374686532821843969", Request ID "80000002-000c-ff00-b63f-84710c7967bb": An unhandled exception was thrown by the application. System.ArgumentOutOfRangeException: The relative expiration value must be positive. (Parameter 'AbsoluteExpirationRelativeToNow')
Actual value was 00:00:00.
   at Microsoft.Extensions.Caching.Memory.MemoryCacheEntryOptions.set_AbsoluteExpirationRelativeToNow(Nullable`1 value)
   at Microsoft.AspNetCore.ResponseCaching.MemoryResponseCache.Set(String key, IResponseCacheEntry entry, TimeSpan validFor)
   at Microsoft.AspNetCore.ResponseCaching.MemoryResponseCache.SetAsync(String key, IResponseCacheEntry entry, TimeSpan validFor)
   at Microsoft.AspNetCore.ResponseCaching.ResponseCachingMiddleware.FinalizeCacheBodyAsync(ResponseCachingContext context)
   at Microsoft.AspNetCore.ResponseCaching.ResponseCachingMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
   at Sentry.AspNetCore.SentryMiddleware.InvokeAsync(HttpContext context)
   at Sentry.AspNetCore.SentryMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync()|url: https://localhost/api/erp/v1/SalesOrders/GetSalesOrders|action: GetSalesOrders
```

Example configuration:
```
"Cache": {
  "Routes": [
    {
      "Route": "/MachineSalesOrders/GetAll",
      "MaxAge": "06:00:00",
      "Vary": []
    }
  ]
}
```