### PR TITLE
EndpointDefinition requires valid route and API

### DIFF
--- a/src/Weikio.ApiFramework.Abstractions/EndpointDefinition.cs
+++ b/src/Weikio.ApiFramework.Abstractions/EndpointDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -6,13 +6,24 @@ namespace Weikio.ApiFramework.Abstractions
 {
     public class EndpointDefinition
     {
-        public EndpointDefinition()
-        {
-        }
-
         public EndpointDefinition(string route, ApiDefinition api, object configuration = null, Func<Endpoint, Task<IHealthCheck>> healthCheckFactory = null, 
             string groupName = null, string name = null, string description = null, string[] tags = null, string policyName = "")
         {
+            if (route == null)
+            { 
+                throw new ArgumentNullException(nameof(route));
+            }
+
+            if (string.IsNullOrWhiteSpace(route))
+            { 
+                throw new ArgumentException("Endpoint route cannot be empty or contain only whitespace characters.", nameof(route));
+            }
+
+            if (api == null)
+            {
+                throw new ArgumentNullException(nameof(api), $"There's no API defined for route '{route}'.");
+            }
+
             Route = route;
             Api = api;
             Configuration = configuration;
@@ -33,11 +44,6 @@ namespace Weikio.ApiFramework.Abstractions
         public string Description { get; set; }
         public string[] Tags { get; set; }
         public string Policy { get; set; }
-        
-        public static implicit operator EndpointDefinition(string route)
-        {
-            return new EndpointDefinition(route, null);
-        }
         
         public static implicit operator EndpointDefinition((string route, ApiDefinition apiDefinition) routeAndApi)
         {

--- a/src/Weikio.ApiFramework.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Weikio.ApiFramework.Core/Extensions/ServiceCollectionExtensions.cs
@@ -233,28 +233,16 @@ namespace Weikio.ApiFramework
             return builder;
         }
         
-        public static IApiFrameworkBuilder AddEndpoint<TApiType>(this IApiFrameworkBuilder builder, string route, object configuration)
-        {
-            var endpointDefinition = new EndpointDefinition(route, null, configuration);
-
-            return builder.AddEndpoint<TApiType>(endpointDefinition);
-        }
-        
-        public static IApiFrameworkBuilder AddEndpoint<TApiType>(this IApiFrameworkBuilder builder, EndpointDefinition endpointDefinition)
+        public static IApiFrameworkBuilder AddEndpoint<TApiType>(this IApiFrameworkBuilder builder, string route, object configuration = null)
         {
             builder.Services.AddSingleton(provider =>
             {
                 return new Func<EndpointDefinition>(() =>
                 {
-                    if (endpointDefinition.Api == null)
-                    {
-                        var apiProvider = provider.GetRequiredService<IApiByAssemblyProvider>();
-                        var api = apiProvider.GetApiByType(typeof(TApiType));
+                    var apiProvider = provider.GetRequiredService<IApiByAssemblyProvider>();
+                    var api = apiProvider.GetApiByType(typeof(TApiType));
 
-                        endpointDefinition.Api = api;
-                    }
-
-                    return endpointDefinition;
+                    return new EndpointDefinition(route, api, configuration);
                 });
             });
 

--- a/tests/unit/ApiFramework.UnitTests/EndpointDefinitionTests.cs
+++ b/tests/unit/ApiFramework.UnitTests/EndpointDefinitionTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Weikio.ApiFramework.Abstractions;
+using Xunit;
+
+namespace ApiFramework.IntegrationTests
+{
+    public class EndpointDefinitionTests
+    {
+        [Fact]
+        public void CannotDefineNullRoute()
+        {
+            Assert.Throws<ArgumentNullException>("route", () =>
+            {
+                new EndpointDefinition(route: null, api: null);
+            });
+        }
+
+        [Fact]
+        public void CannotDefineEmptyRoute()
+        {
+            Assert.Throws<ArgumentException>("route", () =>
+            {
+                new EndpointDefinition(route: "", api: null);
+            });
+        }
+
+        [Fact]
+        public void CannotDefineWhitespaceRoute()
+        {
+            Assert.Throws<ArgumentException>("route", () =>
+            {
+                new EndpointDefinition(route: " ", api: null);
+            });
+        }
+
+        [Fact]
+        public void CannotDefineNullApi()
+        {
+            Assert.Throws<ArgumentNullException>("api", () =>
+            {
+                new EndpointDefinition(route: "/test", api: null);
+            });
+        }
+    }
+}


### PR DESCRIPTION
EndpointDefinition cannot be created without a valid route and ApiDefinition. 

This change introduces only one constructor which validates the required parameters:
- `route`
- `api`